### PR TITLE
[WF] Fix: Remove "previous" and "next" buttons

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -54,7 +54,7 @@ layout: default
 
       {% if page.share %}{% include social-share.html %}{% endif %}
 
-      {% include post_pagination.html %}
+      <!-- {% include post_pagination.html %} -->
     </div>
 
     {% if jekyll.environment == 'production' and site.comments.provider and page.comments %}


### PR DESCRIPTION
Info:
These would otherwise show up for all posts, regardless of category.
