### PR TITLE
set text width to 80%

### DIFF
--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -145,7 +145,7 @@ $medium: 768px !default;
 $medium-wide: 900px !default;
 $large: 1024px !default;
 $x-large: 1280px !default;
-$max-width: 1700px !default;
+$max-width: 1500px !default;
 
 /*
    Grid


### PR DESCRIPTION
Let's discuss text width here.

I propose setting it to 80%, as it improves readability in my opinion.

In case we agree on a narrower text, we should additionally do the following:

- [x] Fix centering (of side bars, text)
